### PR TITLE
infra: reduce earthquake job frequency from 3x/hour to 1x/hour

### DIFF
--- a/terraform/modules/celestial_core/jobs.tf
+++ b/terraform/modules/celestial_core/jobs.tf
@@ -357,8 +357,8 @@ resource "google_cloud_run_v2_job" "ingest_earthquakes_job" {
 # -----------------------------------------------------
 resource "google_cloud_scheduler_job" "ingest_earthquakes_trigger" {
   name             = "schedule-ingest-earthquakes${local.suffix}"
-  description      = "Trigger Cloud Run Job to ingest earthquake data (Every 15 mins)"
-  schedule         = "10,25,40 9-19 * * *" # 15分ごとに実行（Cloud SQL 起動後10分待機、09:10〜19:40、20:00停止前に余裕を持たせる）
+  description      = "Trigger Cloud Run Job to ingest earthquake data (Every hour)"
+  schedule         = "10 9-19 * * *" # 毎時1回（Cloud SQL 起動後10分待機、09:10〜19:10）
   time_zone        = "Asia/Tokyo"
   attempt_deadline = "320s"
 
@@ -464,8 +464,8 @@ resource "google_cloud_run_v2_job" "sync_earthquakes_job" {
 resource "google_cloud_scheduler_job" "sync_earthquakes_trigger" {
   name        = "schedule-sync-earthquakes${local.suffix}"
   description = "Trigger Cloud Run Job to sync earthquake data to DB"
-  # Ingestの5分後に実行 (毎時 15, 30, 45分、Cloud SQL 起動後10分待機、09:15〜19:45)
-  schedule         = "15,30,45 9-19 * * *"
+  # Ingestの5分後に実行 (毎時 15分、Cloud SQL 起動後10分待機、09:15〜19:15)
+  schedule         = "15 9-19 * * *"
   time_zone        = "Asia/Tokyo"
   attempt_deadline = "320s"
 


### PR DESCRIPTION
## Summary

- 地震データの取得・同期ジョブのスケジュールを **毎時3回 → 毎時1回** に変更
- `ingest-earthquakes-job`: `10,25,40 9-19 * * *` → `10 9-19 * * *`
- `sync-earthquakes-db-job`: `15,30,45 9-19 * * *` → `15 9-19 * * *`

## Background

Cloud Run のコスト増加を調査したところ、地震ジョブの追加により Job 実行数が約4倍（~44回/日 → ~180回/日）に増加していることが判明。地震ジョブだけで prod+staging 合計 132回/日実行されており、主要なコスト増加要因となっていた。

ダッシュボード用途であれば1時間ごとの更新で十分なため、頻度を削減する。

## Cost Impact

| 指標 | 変更前 | 変更後 |
|---|---|---|
| 地震ジョブ実行数/日（prod+staging） | 132回 | 44回 |
| 全ジョブ実行数/日（prod+staging） | ~180回 | ~92回 |
| 削減率 | — | 約49% |

## Test plan

- [ ] Terraform plan で差分が scheduler の schedule 変更のみであることを確認
- [ ] staging マージ後、Cloud Scheduler コンソールで新スケジュール（毎時:10、:15）が反映されていることを確認
- [ ] 翌日、`gcloud run jobs executions list` で実行数が減少していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * 地震データの取得および同期スケジュールを15分間隔から1時間間隔に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->