### PR TITLE
ci: ensure Cloud SQL is running before DB migration

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -54,6 +54,47 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
 
+      # Cloud SQL が停止中の場合に起動して RUNNABLE になるまで待機
+      - name: Ensure Cloud SQL is running
+        run: |
+          CONNECTION=$(gcloud run services describe celestial-backend-staging \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }} \
+            --format="value(metadata.annotations['run.googleapis.com/cloudsql-instances'])")
+          INSTANCE=$(echo "$CONNECTION" | cut -d: -f3)
+          echo "Cloud SQL instance: $INSTANCE"
+
+          STATE=$(gcloud sql instances describe "$INSTANCE" \
+            --project ${{ env.PROJECT_ID }} \
+            --format="value(state)")
+          echo "Current state: $STATE"
+
+          if [ "$STATE" != "RUNNABLE" ]; then
+            echo "Starting Cloud SQL instance..."
+            gcloud sql instances patch "$INSTANCE" \
+              --activation-policy=ALWAYS \
+              --project ${{ env.PROJECT_ID }}
+
+            for i in $(seq 1 20); do
+              sleep 15
+              STATE=$(gcloud sql instances describe "$INSTANCE" \
+                --project ${{ env.PROJECT_ID }} \
+                --format="value(state)")
+              echo "State check $i/20: $STATE"
+              if [ "$STATE" = "RUNNABLE" ]; then
+                echo "Cloud SQL is now RUNNABLE"
+                break
+              fi
+            done
+
+            if [ "$STATE" != "RUNNABLE" ]; then
+              echo "::error::Cloud SQL did not become RUNNABLE within 5 minutes"
+              exit 1
+            fi
+          else
+            echo "Cloud SQL is already RUNNABLE"
+          fi
+
       # DBマイグレーションの実行 (Job名に -staging)
       - name: Run DB Migration
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,47 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
 
+      # Cloud SQL が停止中の場合に起動して RUNNABLE になるまで待機
+      - name: Ensure Cloud SQL is running
+        run: |
+          CONNECTION=$(gcloud run services describe celestial-backend \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }} \
+            --format="value(metadata.annotations['run.googleapis.com/cloudsql-instances'])")
+          INSTANCE=$(echo "$CONNECTION" | cut -d: -f3)
+          echo "Cloud SQL instance: $INSTANCE"
+
+          STATE=$(gcloud sql instances describe "$INSTANCE" \
+            --project ${{ env.PROJECT_ID }} \
+            --format="value(state)")
+          echo "Current state: $STATE"
+
+          if [ "$STATE" != "RUNNABLE" ]; then
+            echo "Starting Cloud SQL instance..."
+            gcloud sql instances patch "$INSTANCE" \
+              --activation-policy=ALWAYS \
+              --project ${{ env.PROJECT_ID }}
+
+            for i in $(seq 1 20); do
+              sleep 15
+              STATE=$(gcloud sql instances describe "$INSTANCE" \
+                --project ${{ env.PROJECT_ID }} \
+                --format="value(state)")
+              echo "State check $i/20: $STATE"
+              if [ "$STATE" = "RUNNABLE" ]; then
+                echo "Cloud SQL is now RUNNABLE"
+                break
+              fi
+            done
+
+            if [ "$STATE" != "RUNNABLE" ]; then
+              echo "::error::Cloud SQL did not become RUNNABLE within 5 minutes"
+              exit 1
+            fi
+          else
+            echo "Cloud SQL is already RUNNABLE"
+          fi
+
       # DBマイグレーションの実行 イメージを更新してから実行
       - name: Run DB Migration
         run: |


### PR DESCRIPTION
## Summary

- `deploy.yml`（prod）と `deploy-staging.yml`（staging）の両方に **Ensure Cloud SQL is running** ステップを追加
- `Run DB Migration` の直前に実行し、Cloud SQL が停止中の場合は起動して RUNNABLE になるまで待機する

## Problem

Cloud SQL は 9:00〜20:00 JST のみ稼動するスケジュールになっている。
20:00 JST 以降にデプロイが走ると `migrate-job` が Cloud SQL に接続できず以下のエラーで失敗する:

```
Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
```

実際に PR #112 のマージ（21:23 JST）で発生した。

## Solution

```yaml
- name: Ensure Cloud SQL is running
  run: |
    # celestial-backend サービスのアノテーションからインスタンス名を動的に取得
    CONNECTION=$(gcloud run services describe celestial-backend ...)
    INSTANCE=$(echo "$CONNECTION" | cut -d: -f3)

    # 停止中なら起動して最大 5 分待機
    if [ "$STATE" != "RUNNABLE" ]; then
      gcloud sql instances patch "$INSTANCE" --activation-policy=ALWAYS
      # 15秒おきに最大20回（5分）ポーリング
    fi
```

- インスタンス名はハードコードせず、Cloud Run サービスのアノテーションから動的に取得
- Cloud SQL の 20:00 停止スケジュールは Cloud Scheduler が引き続き管理するため、起動後は翌 20:00 まで稼動する（夜間デプロイ時の許容コスト）

## Notes

WIF SA（`${{ secrets.WIF_SA }}` / `${{ secrets.STAGING_WIF_SA }}`）に `roles/cloudsql.editor` または `cloudsql.instances.update` 権限が必要。未付与の場合はこのステップで明示的なエラーになる。

## Test plan

- [ ] staging マージ後、20:00 JST 以降に staging ブランチへ push してデプロイが通ることを確認
- [ ] Cloud SQL が既に RUNNABLE の場合は "Cloud SQL is already RUNNABLE" とログ出力してスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境と本番環境のデプロイメントワークフローを更新しました。デプロイ実行前のシステム状態確認機能が追加され、デプロイメントプロセスの信頼性と安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->